### PR TITLE
Logger race condition

### DIFF
--- a/include/redox/client.hpp
+++ b/include/redox/client.hpp
@@ -39,7 +39,7 @@
 #include <hiredis/hiredis.h>
 
 #include "command.hpp"
-#include "utils/logger.hpp"
+// #include "utils/logger.hpp"
 
 namespace redox {
 
@@ -69,7 +69,7 @@ public:
   /**
   * Constructor. Optionally specify a log stream and a log level.
   */
-  Redox(std::ostream &log_stream = std::cout, log::Level log_level = log::Warning);
+  Redox();
 
   /**
   * Disconnects from the Redis server, shuts down the event loop, and cleans up.
@@ -231,9 +231,6 @@ public:
 
   // Redox server over unix
   std::string path_;
-
-  // Logger
-  log::Logger logger_;
 
 private:
   // ------------------------------------------------
@@ -412,7 +409,7 @@ Command<ReplyT> &Redox::createCommand(const std::vector<std::string> &cmd,
   }
 
   auto *c = new Command<ReplyT>(this, commands_created_.fetch_add(1), cmd, callback, repeat, after,
-                                free_memory, logger_);
+                                free_memory);
 
   std::lock_guard<std::mutex> lg(queue_guard_);
   std::lock_guard<std::mutex> lg2(command_map_guard_);

--- a/include/redox/command.hpp
+++ b/include/redox/command.hpp
@@ -29,7 +29,7 @@
 #include <hiredis/adapters/libev.h>
 #include <hiredis/async.h>
 
-#include "utils/logger.hpp"
+// #include "utils/logger.hpp"
 
 namespace redox {
 
@@ -102,7 +102,7 @@ public:
 private:
   Command(Redox *rdx, long id, const std::vector<std::string> &cmd,
           const std::function<void(Command<ReplyT> &)> &callback, double repeat, double after,
-          bool free_memory, log::Logger &logger);
+          bool free_memory);
 
   // Handles a new reply from the server
   void processReply(redisReply *r);
@@ -153,9 +153,6 @@ private:
   std::condition_variable waiter_;
   std::mutex waiter_lock_;
   std::atomic_bool waiting_done_ = {false};
-
-  // Passed on from Redox class
-  log::Logger &logger_;
 
   // Explicitly delete copy constructor and assignment operator,
   // Command objects should never be copied because they hold

--- a/include/redox/subscriber.hpp
+++ b/include/redox/subscriber.hpp
@@ -30,7 +30,7 @@ public:
   /**
   * Constructor. Same as Redox.
   */
-  Subscriber(std::ostream &log_stream = std::cout, log::Level log_level = log::Warning);
+  Subscriber();
 
   /**
   * Cleans up.
@@ -157,9 +157,6 @@ private:
 
   // Set of persisting commands, so that we can cancel them
   std::set<Command<redisReply *> *> commands_;
-
-  // Reference to rdx_.logger_ for convenience
-  log::Logger &logger_;
 
   // CVs to wait for unsubscriptions
   std::condition_variable cv_unsub_;

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -312,8 +312,8 @@ void Redox::runEventLoop() {
   // Run once more to disconnect
   ev_run(evloop_, EVRUN_NOWAIT);
 
-  long created = commands_created_;
-  long deleted = commands_deleted_;
+  // long created = commands_created_;
+  // long deleted = commands_deleted_;
 
   // Let go for block_until_stopped method
   setExited(true);

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -45,8 +45,7 @@ void redox_ev_timer_init(ttimer timer, tcb cb, tafter after, trepeat repeat) {
 
 namespace redox {
 
-Redox::Redox(ostream &log_stream, log::Level log_level)
-    : logger_(log_stream, log_level), evloop_(nullptr) {}
+Redox::Redox() : evloop_(nullptr) {}
 
 bool Redox::connect(const string &host, const int port, function<void(int)> connection_callback) {
 
@@ -116,7 +115,6 @@ void Redox::disconnect() {
 
 void Redox::stop() {
   to_exit_ = true;
-  logger_.debug() << "stop() called, breaking event loop";
   ev_async_send(evloop_, &watcher_stop_);
 }
 
@@ -143,12 +141,9 @@ void Redox::connectedCallback(const redisAsyncContext *ctx, int status) {
   Redox *rdx = (Redox *)ctx->data;
 
   if (status != REDIS_OK) {
-    rdx->logger_.fatal() << "Could not connect to Redis: " << ctx->errstr;
-    rdx->logger_.fatal() << "Status: " << status;
     rdx->setConnectState(CONNECT_ERROR);
 
   } else {
-    rdx->logger_.info() << "Connected to Redis.";
     // Disable hiredis automatically freeing reply objects
     ctx->c.reader->fn->freeObject = [](void * /*reply*/) {};
     rdx->setConnectState(CONNECTED);
@@ -164,10 +159,8 @@ void Redox::disconnectedCallback(const redisAsyncContext *ctx, int status) {
   Redox *rdx = (Redox *)ctx->data;
 
   if (status != REDIS_OK) {
-    rdx->logger_.error() << "Disconnected from Redis on error: " << ctx->errstr;
     rdx->setConnectState(DISCONNECT_ERROR);
   } else {
-    rdx->logger_.info() << "Disconnected from Redis as planned.";
     rdx->setConnectState(DISCONNECTED);
   }
 
@@ -181,7 +174,6 @@ bool Redox::initEv() {
   signal(SIGPIPE, SIG_IGN);
   evloop_ = ev_loop_new(EVFLAG_AUTO);
   if (evloop_ == nullptr) {
-    logger_.fatal() << "Could not create a libev event loop.";
     setConnectState(INIT_ERROR);
     return false;
   }
@@ -194,27 +186,23 @@ bool Redox::initHiredis() {
   ctx_->data = (void *)this; // Back-reference
 
   if (ctx_->err) {
-    logger_.fatal() << "Could not create a hiredis context: " << ctx_->errstr;
     setConnectState(INIT_ERROR);
     return false;
   }
 
   // Attach event loop to hiredis
   if (redisLibevAttach(evloop_, ctx_) != REDIS_OK) {
-    logger_.fatal() << "Could not attach libev event loop to hiredis.";
     setConnectState(INIT_ERROR);
     return false;
   }
 
   // Set the callbacks to be invoked on server connection/disconnection
   if (redisAsyncSetConnectCallback(ctx_, Redox::connectedCallback) != REDIS_OK) {
-    logger_.fatal() << "Could not attach connect callback to hiredis.";
     setConnectState(INIT_ERROR);
     return false;
   }
 
   if (redisAsyncSetDisconnectCallback(ctx_, Redox::disconnectedCallback) != REDIS_OK) {
-    logger_.fatal() << "Could not attach disconnect callback to hiredis.";
     setConnectState(INIT_ERROR);
     return false;
   }
@@ -222,13 +210,7 @@ bool Redox::initHiredis() {
   return true;
 }
 
-void Redox::noWait(bool state) {
-  if (state)
-    logger_.info() << "No-wait mode enabled.";
-  else
-    logger_.info() << "No-wait mode disabled.";
-  nowait_ = state;
-}
+void Redox::noWait(bool state) { nowait_ = state; }
 
 void breakEventLoop(struct ev_loop *loop, ev_async * /*async*/, int /*revents*/) {
   ev_break(loop, EVBREAK_ALL);
@@ -284,7 +266,6 @@ void Redox::runEventLoop() {
 
     // Handle connection error
     if (connect_state_ != CONNECTED) {
-      logger_.warning() << "Did not connect, event loop exiting.";
       setExited(true);
       setRunning(false);
       return;
@@ -317,8 +298,6 @@ void Redox::runEventLoop() {
     }
   }
 
-  logger_.info() << "Stop signal detected. Closing down event loop.";
-
   // Signal event loop to free all commands
   freeAllCommands();
 
@@ -335,15 +314,10 @@ void Redox::runEventLoop() {
 
   long created = commands_created_;
   long deleted = commands_deleted_;
-  if (created != deleted) {
-    logger_.error() << "All commands were not freed! " << deleted << "/" << created;
-  }
 
   // Let go for block_until_stopped method
   setExited(true);
   setRunning(false);
-
-  logger_.info() << "Event thread exited.";
 }
 
 template <class ReplyT> Command<ReplyT> *Redox::findCommand(long id) {
@@ -390,7 +364,6 @@ template <class ReplyT> bool Redox::submitToServer(Command<ReplyT> *c) {
 
   if (redisAsyncCommandArgv(rdx->ctx_, commandCallback<ReplyT>, (void *)c->id_, argv.size(),
                             &argv[0], &argvlen[0]) != REDIS_OK) {
-    rdx->logger_.error() << "Could not send \"" << c->cmd() << "\": " << rdx->ctx_->errstr;
     c->reply_status_ = Command<ReplyT>::SEND_ERROR;
     c->invoke();
     return false;
@@ -407,8 +380,6 @@ void Redox::submitCommandCallback(struct ev_loop *loop, ev_timer *timer, int /*r
 
   Command<ReplyT> *c = rdx->findCommand<ReplyT>(id);
   if (c == nullptr) {
-    rdx->logger_.error() << "Couldn't find Command " << id
-                         << " in command_map (submitCommandCallback).";
     return;
   }
 

--- a/src/subscriber.cpp
+++ b/src/subscriber.cpp
@@ -18,15 +18,14 @@
 * limitations under the License.
 */
 
-#include <string.h>
 #include "subscriber.hpp"
+#include <string.h>
 
 using namespace std;
 
 namespace redox {
 
-Subscriber::Subscriber(ostream &log_stream, log::Level log_level)
-    : rdx_(log_stream, log_level), logger_(rdx_.logger_) {}
+Subscriber::Subscriber() : rdx_() {}
 
 Subscriber::~Subscriber() {}
 
@@ -56,16 +55,12 @@ void Subscriber::stop() {
 
   {
     unique_lock<mutex> ul(subscribed_topics_guard_);
-    cv_unsub_.wait(ul, [this] {
-      return (subscribed_topics_.size() == 0);
-    });
+    cv_unsub_.wait(ul, [this] { return (subscribed_topics_.size() == 0); });
   }
 
   {
     unique_lock<mutex> ul(psubscribed_topics_guard_);
-    cv_punsub_.wait(ul, [this] {
-      return (psubscribed_topics_.size() == 0);
-    });
+    cv_punsub_.wait(ul, [this] { return (psubscribed_topics_.size() == 0); });
   }
 
   for (Command<redisReply *> *c : commands_)
@@ -100,76 +95,75 @@ void Subscriber::subscribeBase(const string cmd_name, const string topic,
                                function<void(const string &)> unsub_callback,
                                function<void(const string &, int)> err_callback) {
 
-  Command<redisReply *> &sub_cmd = rdx_.commandLoop<redisReply *>(
-      {cmd_name, topic},
-      [this, topic, msg_callback, err_callback, sub_callback, unsub_callback](
-          Command<redisReply *> &c) {
+  Command<redisReply *> &sub_cmd =
+      rdx_.commandLoop<redisReply *>({cmd_name, topic},
+                                     [this, topic, msg_callback, err_callback, sub_callback,
+                                      unsub_callback](Command<redisReply *> &c) {
 
-        if (!c.ok()) {
-          num_pending_subs_--;
-          if (err_callback)
-            err_callback(topic, c.status());
-          return;
-        }
+                                       if (!c.ok()) {
+                                         num_pending_subs_--;
+                                         if (err_callback)
+                                           err_callback(topic, c.status());
+                                         return;
+                                       }
 
-        redisReply *reply = c.reply();
+                                       redisReply *reply = c.reply();
 
-        // If the last entry is an integer, then it is a [p]sub/[p]unsub command
-        if ((reply->type == REDIS_REPLY_ARRAY) &&
-            (reply->element[reply->elements - 1]->type == REDIS_REPLY_INTEGER)) {
+                                       // If the last entry is an integer, then it is a
+                                       // [p]sub/[p]unsub command
+                                       if ((reply->type == REDIS_REPLY_ARRAY) &&
+                                           (reply->element[reply->elements - 1]->type ==
+                                            REDIS_REPLY_INTEGER)) {
 
+                                         if (!strncmp(reply->element[0]->str, "sub", 3)) {
+                                           lock_guard<mutex> lg(subscribed_topics_guard_);
+                                           subscribed_topics_.insert(topic);
+                                           num_pending_subs_--;
+                                           if (sub_callback)
+                                             sub_callback(topic);
+                                         } else if (!strncmp(reply->element[0]->str, "psub", 4)) {
+                                           lock_guard<mutex> lg(psubscribed_topics_guard_);
+                                           psubscribed_topics_.insert(topic);
+                                           num_pending_subs_--;
+                                           if (sub_callback)
+                                             sub_callback(topic);
+                                         } else if (!strncmp(reply->element[0]->str, "uns", 3)) {
+                                           lock_guard<mutex> lg(subscribed_topics_guard_);
+                                           subscribed_topics_.erase(topic);
+                                           if (unsub_callback)
+                                             unsub_callback(topic);
+                                           cv_unsub_.notify_all();
+                                         } else if (!strncmp(reply->element[0]->str, "puns", 4)) {
+                                           lock_guard<mutex> lg(psubscribed_topics_guard_);
+                                           psubscribed_topics_.erase(topic);
+                                           if (unsub_callback)
+                                             unsub_callback(topic);
+                                           cv_punsub_.notify_all();
+                                         }
 
-          if (!strncmp(reply->element[0]->str, "sub", 3)) {
-            lock_guard<mutex> lg(subscribed_topics_guard_);
-            subscribed_topics_.insert(topic);
-            num_pending_subs_--;
-            if (sub_callback)
-              sub_callback(topic);
-          } else if (!strncmp(reply->element[0]->str, "psub", 4)) {
-            lock_guard<mutex> lg(psubscribed_topics_guard_);
-            psubscribed_topics_.insert(topic);
-            num_pending_subs_--;
-            if (sub_callback)
-              sub_callback(topic);
-          } else if (!strncmp(reply->element[0]->str, "uns", 3)) {
-            lock_guard<mutex> lg(subscribed_topics_guard_);
-            subscribed_topics_.erase(topic);
-            if (unsub_callback)
-              unsub_callback(topic);
-            cv_unsub_.notify_all();
-          } else if (!strncmp(reply->element[0]->str, "puns", 4)) {
-            lock_guard<mutex> lg(psubscribed_topics_guard_);
-            psubscribed_topics_.erase(topic);
-            if (unsub_callback)
-              unsub_callback(topic);
-            cv_punsub_.notify_all();
-          }
+                                       }
 
-          else
-            logger_.error() << "Unknown pubsub message: " << reply->element[0]->str;
-        }
+                                       // Message for subscribe
+                                       else if ((reply->type == REDIS_REPLY_ARRAY) &&
+                                                (reply->elements == 3)) {
+                                         char *msg = reply->element[2]->str;
+                                         int len = reply->element[2]->len;
+                                         if (msg && msg_callback)
+                                           msg_callback(topic, string(msg, len));
+                                       }
 
-        // Message for subscribe
-        else if ((reply->type == REDIS_REPLY_ARRAY) && (reply->elements == 3)) {
-          char *msg = reply->element[2]->str;
-          int len = reply->element[2]->len;
-          if (msg && msg_callback)
-            msg_callback(topic, string(msg, len));
-        }
+                                       // Message for psubscribe
+                                       else if ((reply->type == REDIS_REPLY_ARRAY) &&
+                                                (reply->elements == 4)) {
+                                         char *msg = reply->element[3]->str;
+                                         int len = reply->element[3]->len;
+                                         if (msg && msg_callback)
+                                           msg_callback(reply->element[2]->str, string(msg, len));
+                                       }
 
-        // Message for psubscribe
-        else if ((reply->type == REDIS_REPLY_ARRAY) && (reply->elements == 4)) {
-          char *msg = reply->element[3]->str;
-          int len = reply->element[3]->len;
-          if (msg && msg_callback)
-            msg_callback(reply->element[2]->str, string(msg, len));
-        }
-
-        else
-          logger_.error() << "Unknown pubsub message of type " << reply->type;
-      },
-      1e10 // To keep the command around for a few hundred years
-      );
+                                     },
+                                     1e10 // To keep the command around for a few hundred years
+                                     );
 
   // Add it to the command list
   commands_.insert(&sub_cmd);
@@ -183,7 +177,6 @@ void Subscriber::subscribe(const string topic,
                            function<void(const string &, int)> err_callback) {
   lock_guard<mutex> lg(subscribed_topics_guard_);
   if (subscribed_topics_.find(topic) != subscribed_topics_.end()) {
-    logger_.warning() << "Already subscribed to " << topic << "!";
     return;
   }
   subscribeBase("SUBSCRIBE", topic, msg_callback, sub_callback, unsub_callback, err_callback);
@@ -196,7 +189,6 @@ void Subscriber::psubscribe(const string topic,
                             function<void(const string &, int)> err_callback) {
   lock_guard<mutex> lg(psubscribed_topics_guard_);
   if (psubscribed_topics_.find(topic) != psubscribed_topics_.end()) {
-    logger_.warning() << "Already psubscribed to " << topic << "!";
     return;
   }
   subscribeBase("PSUBSCRIBE", topic, msg_callback, sub_callback, unsub_callback, err_callback);
@@ -216,7 +208,6 @@ void Subscriber::unsubscribeBase(const string cmd_name, const string topic,
 void Subscriber::unsubscribe(const string topic, function<void(const string &, int)> err_callback) {
   lock_guard<mutex> lg(subscribed_topics_guard_);
   if (subscribed_topics_.find(topic) == subscribed_topics_.end()) {
-    logger_.warning() << "Cannot unsubscribe from " << topic << ", not subscribed!";
     return;
   }
   unsubscribeBase("UNSUBSCRIBE", topic, err_callback);
@@ -226,7 +217,6 @@ void Subscriber::punsubscribe(const string topic,
                               function<void(const string &, int)> err_callback) {
   lock_guard<mutex> lg(psubscribed_topics_guard_);
   if (psubscribed_topics_.find(topic) == psubscribed_topics_.end()) {
-    logger_.warning() << "Cannot punsubscribe from " << topic << ", not psubscribed!";
     return;
   }
   unsubscribeBase("PUNSUBSCRIBE", topic, err_callback);

--- a/src/utils/logger.cpp
+++ b/src/utils/logger.cpp
@@ -6,8 +6,8 @@
 */
 
 #include "utils/logger.hpp"
-#include <iostream>
 #include <iomanip>
+#include <iostream>
 
 // needed for MSVC
 #ifdef WIN32
@@ -20,26 +20,22 @@ namespace log {
 // Convert date and time info from tm to a character string
 // in format "YYYY-mm-DD HH:MM:SS" and send it to a stream
 std::ostream &operator<<(std::ostream &stream, const tm *tm) {
-// I had to muck around this section since GCC 4.8.1 did not implement std::put_time
-//	return stream << std::put_time(tm, "%Y-%m-%d %H:%M:%S");
-  return stream << 1900 + tm->tm_year << '-' <<
-    std::setfill('0') << std::setw(2) << tm->tm_mon + 1 << '.'
-    << std::setfill('0') << std::setw(2) << tm->tm_mday << ' '
-    << std::setfill('0') << std::setw(2) << tm->tm_hour << ':'
-    << std::setfill('0') << std::setw(2) << tm->tm_min << ':'
-    << std::setfill('0') << std::setw(2) << tm->tm_sec;
+  // I had to muck around this section since GCC 4.8.1 did not implement std::put_time
+  //	return stream << std::put_time(tm, "%Y-%m-%d %H:%M:%S");
+  return stream << 1900 + tm->tm_year << '-' << std::setfill('0') << std::setw(2) << tm->tm_mon + 1
+                << '.' << std::setfill('0') << std::setw(2) << tm->tm_mday << ' '
+                << std::setfill('0') << std::setw(2) << tm->tm_hour << ':' << std::setfill('0')
+                << std::setw(2) << tm->tm_min << ':' << std::setfill('0') << std::setw(2)
+                << tm->tm_sec;
 }
 
 // --------------------
 // Logstream
 // --------------------
 
-Logstream::Logstream(Logger &logger, Level loglevel) :
-  m_logger(logger), m_loglevel(loglevel) {
-}
+Logstream::Logstream(Logger &logger, Level loglevel) : m_logger(logger), m_loglevel(loglevel) {}
 
-Logstream::Logstream(const Logstream &ls) :
-  m_logger(ls.m_logger), m_loglevel(ls.m_loglevel) {
+Logstream::Logstream(const Logstream &ls) : m_logger(ls.m_logger), m_loglevel(ls.m_loglevel) {
   // As of GCC 8.4.1 basic_stream is still lacking a copy constructor
   // (part of C++11 specification)
   //
@@ -48,7 +44,7 @@ Logstream::Logstream(const Logstream &ls) :
 }
 
 Logstream::~Logstream() {
-  if(m_logger.level() <= m_loglevel)
+  if (m_logger.level() <= m_loglevel)
     m_logger.log(m_loglevel, this->str());
 }
 
@@ -56,16 +52,13 @@ Logstream::~Logstream() {
 // Logger
 // --------------------
 
-Logger::Logger(std::string filename, Level loglevel) :
-  m_file(filename, std::fstream::out | std::fstream::app | std::fstream::ate),
-  m_stream(m_file), m_loglevel(loglevel) {}
+Logger::Logger(std::string filename, Level loglevel)
+    : m_file(filename, std::fstream::out | std::fstream::app | std::fstream::ate), m_stream(m_file),
+      m_loglevel(loglevel) {}
 
-Logger::Logger(std::ostream &outfile, Level loglevel) :
-  m_stream(outfile), m_loglevel(loglevel) {}
+Logger::Logger(std::ostream &outfile, Level loglevel) : m_stream(outfile), m_loglevel(loglevel) {}
 
-Logger::~Logger() {
-  m_stream.flush();
-}
+Logger::~Logger() { m_stream.flush(); }
 
 const tm *Logger::getLocalTime() {
   auto in_time_t = std::chrono::system_clock::to_time_t(std::chrono::system_clock::now());
@@ -74,14 +67,11 @@ const tm *Logger::getLocalTime() {
 }
 
 void Logger::log(Level l, std::string oMessage) {
-  const static char *LevelStr[] = {
-    "[Trace]  ", "[Debug]  ", "[Info]   ", "[Warning]", "[Error]  ", "[Fatal]  "
-  };
+  const static char *LevelStr[] = {"[Trace]  ", "[Debug]  ", "[Info]   ",
+                                   "[Warning]", "[Error]  ", "[Fatal]  "};
 
   m_lock.lock();
-  m_stream << '(' << getLocalTime() << ") "
-    << LevelStr[l] << "\t"
-    << oMessage << std::endl;
+  m_stream << '(' << getLocalTime() << ") " << LevelStr[l] << "\t" << oMessage << std::endl;
   m_lock.unlock();
 }
 


### PR DESCRIPTION
We remove logging because Clipper does it's own logging and error handling and I ran into a race condition in the Redox Logger (specifically, in the `Logstream` destructor).